### PR TITLE
!etimer add expired 

### DIFF
--- a/core/sys/etimer.c
+++ b/core/sys/etimer.c
@@ -169,8 +169,11 @@ add_timer(struct etimer *timer)
 
   // this is protection vs addin alredy expired timers
   if (timer_expired_at(&timer->timer, now)){
-      //process_post(proc, PROCESS_EVENT_TIMER, timer);
-      // PRINTF("etimer: alredy expired\n");
+      //some APP try use immediate expired timers, for Delayed ProcCall.
+      //    handle such events as valid active ordinary notify mesasges
+      if (timer->timer.interval > 0)
+          process_post(proc, PROCESS_EVENT_TIMER, timer);
+      PRINTF("etimer(%p): alredy expired\n", timer);
       return;
   }
 

--- a/core/sys/etimer.c
+++ b/core/sys/etimer.c
@@ -169,7 +169,7 @@ add_timer(struct etimer *timer)
 
   // this is protection vs addin alredy expired timers
   if (timer_expired_at(&timer->timer, now)){
-      process_post(proc, PROCESS_EVENT_TIMER, timer);
+      //process_post(proc, PROCESS_EVENT_TIMER, timer);
       // PRINTF("etimer: alredy expired\n");
       return;
   }

--- a/core/sys/etimer.c
+++ b/core/sys/etimer.c
@@ -167,6 +167,13 @@ add_timer(struct etimer *timer)
     etimer_stop(timer);
   }
 
+  // this is protection vs addin alredy expired timers
+  if (timer_expired_at(&timer->timer, now)){
+      process_post(proc, PROCESS_EVENT_TIMER, timer);
+      // PRINTF("etimer: alredy expired\n");
+      return;
+  }
+
   timer->p = proc;
 
   if(timerlist == NULL || etimer_lte(timer, timerlist, now)) {


### PR DESCRIPTION
* such timer can be created by etimer_reset, and if it will starts, leads to unnesasary
        etimer lists rebuilds, and even to process events que overload.